### PR TITLE
Add error handling to `news` feature

### DIFF
--- a/stock-tracker/src/app/App.js
+++ b/stock-tracker/src/app/App.js
@@ -1,8 +1,8 @@
 import './App.css';
 import Header from '../components/header/Header';
 import Home from '../components/home/Home';
-import { Routes, Route } from 'react-router-dom';
 import News from '../components/news/News';
+import { Routes, Route } from 'react-router-dom';
 
 // The Header component will persist on all pages, so it will be placed in the App component.
 // The header component will contain the site title and navigation links as well as the stock ticker.

--- a/stock-tracker/src/app/App.js
+++ b/stock-tracker/src/app/App.js
@@ -2,6 +2,7 @@ import './App.css';
 import Header from '../components/header/Header';
 import Home from '../components/home/Home';
 import { Routes, Route } from 'react-router-dom';
+import News from '../components/news/News';
 
 // The Header component will persist on all pages, so it will be placed in the App component.
 // The header component will contain the site title and navigation links as well as the stock ticker.
@@ -13,7 +14,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/comparison" element={<h1>Comparison</h1>} />
-        <Route path="/news" element={<h1>News</h1>} />
+        <Route path="/news" element={<News />} />
       </Routes>
     </div>
   );

--- a/stock-tracker/src/components/news/News.js
+++ b/stock-tracker/src/components/news/News.js
@@ -76,7 +76,7 @@ function News(props) {
         </Form>
 
         {news.length ? (
-          news.map((item, index) => (
+          news.slice(0, 20).map((item, index) => (
             <Card className="mb-4 w-50 mx-auto" key={index}>
               <Card.Img variant="top" src={item.image} />
               <Card.Body>

--- a/stock-tracker/src/components/news/News.js
+++ b/stock-tracker/src/components/news/News.js
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react';
+
+function News(props) {
+  const [news, setNews] = useState([]);
+
+  useEffect(() => {
+    const fetchNews = async () => {
+      const response = await fetch(
+        `https://finnhub.io/api/v1/company-news?symbol=AAPL&from=2023-01-01&to=2023-05-01&token=${process.env.REACT_APP_FINNHUB_API_KEY}`,
+      );
+
+      if (!response.ok) {
+        console.error(`HTTP error! status: ${response.status}`);
+        return;
+      }
+
+      const data = await response.json();
+      console.log('news', data);
+      setNews(data);
+    };
+
+    fetchNews();
+  }, []);
+
+  return (
+    <div className="news">
+      <h1>Financial News Hub</h1>
+      {news.length ? (
+        news.map((item, index) => (
+          <div key={index}>
+            <h2>{item.headline}</h2>
+            <p>{item.summary}</p>
+          </div>
+        ))
+      ) : (
+        <p>Coming soon...</p>
+      )}
+    </div>
+  );
+}
+
+export default News;

--- a/stock-tracker/src/components/news/News.js
+++ b/stock-tracker/src/components/news/News.js
@@ -79,7 +79,7 @@ function News(props) {
     <div className="news">
       <Container className="mt-0">
         <Form className="mb-4" onSubmit={handleSearchSubmit}>
-          <InputGroup className="w-25 mx-auto">
+          <InputGroup className="w-50 mx-auto">
             <Form.Control
               type="text"
               value={search}

--- a/stock-tracker/src/components/news/News.js
+++ b/stock-tracker/src/components/news/News.js
@@ -1,65 +1,97 @@
 import React, { useState, useEffect } from 'react';
-
-// Defaults to get one month of company news
+import Form from 'react-bootstrap/Form';
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import Container from 'react-bootstrap/Container';
+import InputGroup from 'react-bootstrap/InputGroup';
 
 function News(props) {
   const [news, setNews] = useState([]);
+  const [search, setSearch] = useState('');
 
-  useEffect(() => {
-    const fetchNews = async () => {
-      const today = new Date();
-      const monthAgo = new Date();
-      monthAgo.setMonth(today.getMonth() - 1);
+  const fetchNews = async (symbol) => {
+    const today = new Date();
+    const monthAgo = new Date();
+    monthAgo.setMonth(today.getMonth() - 1);
 
-      const formatDate = (date) => {
-        const year = date.getFullYear();
-        let month = date.getMonth() + 1; // months are zero indexed
-        let day = date.getDate();
+    const formatDate = (date) => {
+      const year = date.getFullYear();
+      let month = date.getMonth() + 1; // months are zero indexed
+      let day = date.getDate();
 
-        // prepend month or day with zero if single digit
-        if (month < 10) {
-          month = `0${month}`;
-        }
-        if (day < 10) {
-          day = `0${day}`;
-        }
-
-        return `${year}-${month}-${day}`;
-      };
-
-      console.log('today', formatDate(today));
-      console.log('monthAgo', formatDate(monthAgo));
-
-      const response = await fetch(
-        `https://finnhub.io/api/v1/company-news?symbol=AAPL&from=2023-01-01&to=2023-05-01&token=${process.env.REACT_APP_FINNHUB_API_KEY}`,
-      );
-
-      if (!response.ok) {
-        console.error(`HTTP error! status: ${response.status}`);
-        return;
+      // prepend month or day with zero if single digit
+      if (month < 10) {
+        month = `0${month}`;
+      }
+      if (day < 10) {
+        day = `0${day}`;
       }
 
-      const data = await response.json();
-      console.log('news', data);
-      setNews(data);
+      return `${year}-${month}-${day}`;
     };
 
-    fetchNews();
-  }, []);
+    console.log('today', formatDate(today));
+    console.log('monthAgo', formatDate(monthAgo));
+
+    const response = await fetch(
+      `https://finnhub.io/api/v1/company-news?symbol=${symbol}&from=${formatDate(
+        monthAgo,
+      )}&to=${formatDate(today)}&token=${
+        process.env.REACT_APP_FINNHUB_API_KEY
+      }`,
+    );
+
+    if (!response.ok) {
+      console.error(`HTTP error! status: ${response.status}`);
+      return;
+    }
+
+    const data = await response.json();
+    console.log('news', data);
+    setNews(data);
+  };
+
+  const handleSearchChange = (event) => {
+    setSearch(event.target.value);
+  };
+
+  const handleSearchSubmit = (event) => {
+    event.preventDefault();
+    fetchNews(search);
+  };
 
   return (
     <div className="news">
-      <h1>Financial News Hub</h1>
-      {news.length ? (
-        news.map((item, index) => (
-          <div key={index}>
-            <h2>{item.headline}</h2>
-            <p>{item.summary}</p>
+      <Container className="mt-0">
+        <Form className="mb-4" onSubmit={handleSearchSubmit}>
+          <InputGroup className="w-25 mx-auto">
+            <Form.Control
+              type="text"
+              value={search}
+              onChange={handleSearchChange}
+              placeholder="Search by company symbol..."
+            />
+            <Button type="submit">Search</Button>
+          </InputGroup>
+        </Form>
+
+        {news.length ? (
+          news.map((item, index) => (
+            <Card className="mb-4 w-50 mx-auto" key={index}>
+              <Card.Img variant="top" src={item.image} />
+              <Card.Body>
+                <Card.Title>{item.headline}</Card.Title>
+                <Card.Text>{item.summary}</Card.Text>
+                <Card.Link href={item.url}>Full article</Card.Link>
+              </Card.Body>
+            </Card>
+          ))
+        ) : (
+          <div className="d-flex justify-content-center">
+            <p>Enter a stock symbol to retrieve company news...</p>
           </div>
-        ))
-      ) : (
-        <p>Failed to load news data...</p>
-      )}
+        )}
+      </Container>
     </div>
   );
 }

--- a/stock-tracker/src/components/news/News.js
+++ b/stock-tracker/src/components/news/News.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';

--- a/stock-tracker/src/components/news/News.js
+++ b/stock-tracker/src/components/news/News.js
@@ -1,10 +1,35 @@
 import React, { useState, useEffect } from 'react';
 
+// Defaults to get one month of company news
+
 function News(props) {
   const [news, setNews] = useState([]);
 
   useEffect(() => {
     const fetchNews = async () => {
+      const today = new Date();
+      const monthAgo = new Date();
+      monthAgo.setMonth(today.getMonth() - 1);
+
+      const formatDate = (date) => {
+        const year = date.getFullYear();
+        let month = date.getMonth() + 1; // months are zero indexed
+        let day = date.getDate();
+
+        // prepend month or day with zero if single digit
+        if (month < 10) {
+          month = `0${month}`;
+        }
+        if (day < 10) {
+          day = `0${day}`;
+        }
+
+        return `${year}-${month}-${day}`;
+      };
+
+      console.log('today', formatDate(today));
+      console.log('monthAgo', formatDate(monthAgo));
+
       const response = await fetch(
         `https://finnhub.io/api/v1/company-news?symbol=AAPL&from=2023-01-01&to=2023-05-01&token=${process.env.REACT_APP_FINNHUB_API_KEY}`,
       );
@@ -33,7 +58,7 @@ function News(props) {
           </div>
         ))
       ) : (
-        <p>Coming soon...</p>
+        <p>Failed to load news data...</p>
       )}
     </div>
   );

--- a/stock-tracker/src/components/news/News.js
+++ b/stock-tracker/src/components/news/News.js
@@ -8,8 +8,14 @@ import InputGroup from 'react-bootstrap/InputGroup';
 function News(props) {
   const [news, setNews] = useState([]);
   const [search, setSearch] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
 
   const fetchNews = async (symbol) => {
+    if (!symbol) {
+      setErrorMessage('Please enter a stock symbol.');
+      setNews([]);
+      return;
+    }
     const today = new Date();
     const monthAgo = new Date();
     monthAgo.setMonth(today.getMonth() - 1);
@@ -42,17 +48,26 @@ function News(props) {
     );
 
     if (!response.ok) {
+      setErrorMessage('Symbol not found. Please enter a valid stock symbol.');
+      setNews([]);
       console.error(`HTTP error! status: ${response.status}`);
       return;
     }
 
     const data = await response.json();
+    if (data.length === 0) {
+      setErrorMessage('Symbol not found. Please enter a valid stock symbol.');
+      setNews([]);
+      return;
+    }
     console.log('news', data);
+    setErrorMessage('');
     setNews(data);
   };
 
   const handleSearchChange = (event) => {
     setSearch(event.target.value);
+    setErrorMessage('');
   };
 
   const handleSearchSubmit = (event) => {
@@ -74,6 +89,12 @@ function News(props) {
             <Button type="submit">Search</Button>
           </InputGroup>
         </Form>
+
+        {errorMessage && (
+          <div className="d-flex justify-content-center">
+            <p style={{ color: 'red' }}>{errorMessage}</p>
+          </div>
+        )}
 
         {news.length ? (
           news.slice(0, 20).map((item, index) => (


### PR DESCRIPTION
In the now-merged PR for the `feature/company-news` branch, submitting null or invalid data didn't display any on-screen error messages.

This:
- renders red error message on screen when bad form submissions are made, and
- covers null and invalid cases.

It's pretty broad and throws the `invalid symbol` message for any HTTP error, but it should work for the cases we need to cover.