### PR TITLE
Fix some ticker issues, touch up donuts

### DIFF
--- a/stock-tracker/src/components/chart/Donut.css
+++ b/stock-tracker/src/components/chart/Donut.css
@@ -14,7 +14,7 @@ h1 {
 .donut-chart {
   padding: 1rem;
   border-radius: 0.8rem;
-  background-color: #ffffff;
+  background-color: #f8f9fa;
 }
 
 .chart-legend {

--- a/stock-tracker/src/components/header/Header.js
+++ b/stock-tracker/src/components/header/Header.js
@@ -1,7 +1,6 @@
 import './Header.css';
 import Navigation from '../navigation/Navigation';
 import Ticker from '../ticker/Ticker';
-import '../ticker/Ticker.css';
 
 // This file will contain the header for the site that will persist regardless of navigation.
 // It will contain the site title and navigation links as well as the stock ticker.

--- a/stock-tracker/src/components/ticker/Ticker.css
+++ b/stock-tracker/src/components/ticker/Ticker.css
@@ -11,24 +11,12 @@
   color: #fff;
 }
 
-/* Hide the scrollbar for non-touch devices */
-@media (hover: none) and (pointer: coarse) {
-  .stock-ticker {
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE and Edge */
-  }
-}
-
-/* Hide the scrollbar for WebKit browsers */
-.stock-ticker::-webkit-scrollbar {
-  display: none;
-}
-
 .stock-item {
   display: inline-block;
-  width: 100px;
+  min-width: 100px;
   padding: 0 10px;
   font-size: 10px;
+  text-align: center;
 }
 
 .stock-symbol {
@@ -40,7 +28,8 @@
 /* Handle changePercent and change together */
 .stock-change-wrapper {
   display: flex;
-  width: 64px;
+  flex-grow: 1;
+  width: 100%;
   align-items: center;
   margin-top: 1px;
   justify-content: center;
@@ -54,7 +43,7 @@
 
 .stock-change-percent {
   margin-right: 5px;
-  width: 10px;
+  width: 100%;
 }
 
 .stock-change.positive {

--- a/stock-tracker/src/components/ticker/Ticker.css
+++ b/stock-tracker/src/components/ticker/Ticker.css
@@ -34,12 +34,13 @@
 .stock-symbol {
   font-weight: bold;
   font-size: 12px;
-  margin-right: 7px;
+  margin-right: 5px;
 }
 
 /* Handle changePercent and change together */
 .stock-change-wrapper {
   display: flex;
+  width: 64px;
   align-items: center;
   margin-top: 1px;
   justify-content: center;

--- a/stock-tracker/src/components/ticker/Ticker.js
+++ b/stock-tracker/src/components/ticker/Ticker.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import useWebSocket from 'react-use-websocket';
-//import './ticker.css';
+import './Ticker.css';
 
 const Ticker = () => {
   const tickerContainerRef = useRef(null);
@@ -13,9 +13,9 @@ const Ticker = () => {
     ]
       .map((symbol) => ({
         symbol,
-        price: "000.00",
-        change: "0.00",
-        changePercent: "0.00",
+        price: Number(0).toFixed(3),
+        change: Number(0).toFixed(2),
+        changePercent: Number(0).toFixed(2),
       }))
   );
   //  Configure socket for receiving stock data
@@ -38,13 +38,13 @@ const Ticker = () => {
                 (trade) => trade.s === stock.symbol);
               if (match) {
                 const diff = match.p - stock.price;
-                const changePercent = stock.price !== 0 ?
-                  (diff / stock.price * 100).toFixed(2) : 0;
+                const changePercent = Number(stock.price) !== 0 ?
+                  (diff / Number(stock.price) * 100).toFixed(2) : 0;
                 return {
                   ...stock,
                   price: Number(match.p).toFixed(2),
                   change: Number(diff).toFixed(2),
-                  changePercent: `${changePercent}%`,
+                  changePercent: isFinite(changePercent) ? `${Number(changePercent).toFixed(2)}%` : Number(0).toFixed(2),
                 };
               }
             } catch (error) {
@@ -92,7 +92,7 @@ const Ticker = () => {
             <span className="stock-price">
               {stock.price}
             </span>
-            <div className="stock-change-wrapper justify-content-center">
+            <div className="stock-change-wrapper">
               <div className={`stock-change ${stock.change < 0 ? 'negative' :
                                stock.change > 0 ? 'positive' : ''}`}>
                 <span className={`arrow ${stock.change < 0 ? 'negative' : ''}`}>
@@ -103,7 +103,7 @@ const Ticker = () => {
                   {stock.changePercent}
                 </span>
                 <span className="stock-change">
-                  ({stock.change === 0 ? "0.00" : stock.change})
+                  ({stock.change === 0 ? Number(0).toFixed(2) : stock.change})
                 </span>
               </div>
             </div>


### PR DESCRIPTION
Ticker items are now spaced a little further apart so there shouldn't be any more collisions when the values change. This reduces a lot of its jitteriness.

This also fixes the rendering of `Infinity` when first changing a value from its default zero.

Also adds gray background to donuts so they fit into the home page better.