### PR TITLE
Add news donut, tooltip support

### DIFF
--- a/stock-tracker/src/components/chart/Donut.js
+++ b/stock-tracker/src/components/chart/Donut.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useMemo } from 'react';
-import { ArcElement, Chart, DoughnutController, Legend, Title } from 'chart.js';
+import { ArcElement, Chart, DoughnutController, Legend, Title, Tooltip } from 'chart.js';
 import './Donut.css';
 
 //const totalTechMarketCap = 21852000;
@@ -84,12 +84,24 @@ const Donut = ({title, labels, dataset}) => {
                 padding: 30,
               },
             },
+            tooltip: {
+              enabled: true,
+              callbacks: {
+                label: function (context) {
+                  const label = context.label || '';
+                  const value = context.raw || '';
+
+                  // Customize the tooltip label
+                  return `${label}: ${value}`;
+                },
+              },
+            },
           },
         },
       });
     };
 
-    Chart.register(ArcElement, DoughnutController, Legend, Title);
+    Chart.register(ArcElement, DoughnutController, Legend, Title, Tooltip);
     renderChart();
 
   }, [title, labels, dataset, backgroundColors, borderColors]);

--- a/stock-tracker/src/components/chart/Donut.js
+++ b/stock-tracker/src/components/chart/Donut.js
@@ -88,11 +88,10 @@ const Donut = ({title, labels, dataset}) => {
               enabled: true,
               callbacks: {
                 label: function (context) {
-                  const label = context.label || '';
                   const value = context.raw || '';
 
                   // Customize the tooltip label
-                  return `${label}: ${value}`;
+                  return `${value}`;
                 },
               },
             },

--- a/stock-tracker/src/components/home/Home.js
+++ b/stock-tracker/src/components/home/Home.js
@@ -3,7 +3,6 @@ import './Home.css';
 import CandleStick from '../chart/CandleStick';
 import Details from '../details/Details';
 import Donut from '../chart/Donut';
-import '../chart/Donut.css';
 
 // Per wireframe:
 // Home page will contain a search input for bringing up the stock details modal.
@@ -67,14 +66,13 @@ async function fetchMarketCaps(symbols) {
               console.error(error);
               reject(error);
             } else {
-              resolve(data['marketCapitalization']);
+              resolve(parseInt(data['marketCapitalization']));
             }
           });
         });
       })
     );
 
-    // Process the marketCaps array
     marketCaps.forEach((marketCap, index) => {
       console.log(`${symbols[index]} market cap: ${parseInt(marketCap)}`);
     });

--- a/stock-tracker/src/components/home/Home.js
+++ b/stock-tracker/src/components/home/Home.js
@@ -4,11 +4,6 @@ import CandleStick from '../chart/CandleStick';
 import Details from '../details/Details';
 import Donut from '../chart/Donut';
 
-// Per wireframe:
-// Home page will contain a search input for bringing up the stock details modal.
-// Home page will contain three candlestick charts for common stocks?. Composite indices are premium finnhub features.
-// Home page will coantain a sector map or some other chart thing.
-
 function Home() {
   const [marketCaps, setMarketCaps] = useState([]);
   const [newsData, setNewsData] = useState([]);
@@ -20,8 +15,8 @@ function Home() {
     const fetchData = async () => {
       const marketCaps = await fetchMarketCaps(bigFive);
       const news = await fetchNews(bigFive);
-      setNewsData(news);
       setMarketCaps(marketCaps);
+      setNewsData(news);
     };
     fetchData();
   }, [bigFive]);

--- a/stock-tracker/src/components/home/Home.js
+++ b/stock-tracker/src/components/home/Home.js
@@ -19,17 +19,11 @@ function Home() {
   useEffect(() => {
     const fetchData = async () => {
       const marketCaps = await fetchMarketCaps(bigFive);
+      const news = await fetchNews(bigFive);
+      setNewsData(news);
       setMarketCaps(marketCaps);
     };
     fetchData();
-  }, [bigFive]);
-
-  useEffect(() => {
-    const fetchNewsData = async () => {
-      const news = await fetchNews(bigFive);
-      setNewsData(news);
-    };
-    fetchNewsData();
   }, [bigFive]);
 
   return (


### PR DESCRIPTION
Adds a helper function to `Home.js` that fetches number of news stories published daily for each of the Big Five. At this point, the donuts aren't being used in such a generalizable way that we need this pattern, but oh well.

Also adds tooltip support for the `Donut` component so that when the user hovers their cursor over sections of the donut, its numerical value is displayed in a pop-up.